### PR TITLE
Introduce event for archive rotation of logs

### DIFF
--- a/schema/echofish-dataonly.sql
+++ b/schema/echofish-dataonly.sql
@@ -28,7 +28,7 @@ insert into sysconf (id,val) VALUES ('archive_activated','yes'),
 									('archive_rotate','yes'),
 									('archive_delete_use_mem','no'),
 									('archive_delete_days',7),
-									('archive_delete_limit', 0)
+									('archive_delete_limit',0)
 							 ON DUPLICATE KEY UPDATE id=VALUES(id);
 
 --

--- a/schema/echofish-dataonly.sql
+++ b/schema/echofish-dataonly.sql
@@ -24,7 +24,11 @@ SET time_zone = "+00:00";
 -- Dumping data for table `sysconf`
 --
 insert into sysconf (id,val) VALUES ('archive_activated','yes'),
-									('whitelist_archived','no') 
+									('whitelist_archived','no'),
+									('archive_rotate','yes'),
+									('archive_delete_use_mem','no'),
+									('archive_delete_days',7),
+									('archive_delete_limit', 0)
 							 ON DUPLICATE KEY UPDATE id=VALUES(id);
 
 --

--- a/schema/echofish-events.sql
+++ b/schema/echofish-events.sql
@@ -3,7 +3,7 @@
 SET FOREIGN_KEY_CHECKS=0;
 SET SQL_MODE="NO_AUTO_VALUE_ON_ZERO";
 SET time_zone = "+00:00";
-
+SET NAMES utf8 COLLATE 'utf8_unicode_ci';
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
@@ -32,3 +32,43 @@ BEGIN
   ALTER EVENT e_archive_parse_unparsed ENABLE;
 END
 //
+
+DROP EVENT IF EXISTS e_rotate_archive//
+CREATE EVENT e_rotate_archive
+ON SCHEDULE EVERY 1 DAY COMMENT 'ROTATE OLD ARCHIVE ENTRIES' DO
+BEGIN
+IF (SELECT count(*) FROM sysconf WHERE id='archive_rotate' and val='yes')>0 THEN
+  SET @archive_days=IFNULL((SELECT val FROM sysconf WHERE id='archive_delete_days'),7);
+  SET @archive_limit=IFNULL((SELECT val FROM sysconf WHERE id='archive_delete_limit'),0);
+  SET @use_mem=IFNULL((SELECT val FROM sysconf WHERE id='archive_delete_use_mem'),'no');
+  IF @archive_days>0 THEN
+	IF @use_mem != 'yes' THEN
+  	  CREATE TEMPORARY TABLE archive_ids (id BIGINT UNSIGNED NOT NULL PRIMARY KEY);
+  	ELSE
+  	  CREATE TEMPORARY TABLE archive_ids (id BIGINT UNSIGNED NOT NULL PRIMARY KEY) ENGINE=MEMORY;
+	END IF;
+	
+	SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+	START TRANSACTION;
+	IF @archive_limit > 0 THEN
+    	PREPARE choose_archive_ids FROM 'INSERT INTO archive_ids SELECT id FROM `archive` WHERE received_ts < NOW() - INTERVAL ? DAY LIMIT ?';
+	   	EXECUTE choose_archive_ids USING @archive_days, @archive_limit;
+    ELSE
+    	PREPARE choose_archive_ids FROM 'INSERT INTO archive_ids SELECT id FROM `archive` WHERE received_ts < NOW() - INTERVAL ?';
+	   	EXECUTE choose_archive_ids USING @archive_days;
+	END IF;
+	DEALLOCATE PREPARE choose_archive_ids;
+	-- Ignore ID's from entries that exist on archive_unparse
+	DELETE t1.* FROM archive_ids as t1 LEFT JOIN archive_unparse AS t2 ON t1.id=t2.id WHERE t2.id IS NOT NULL;
+	-- Ignore ID's from entries that exist on syslog
+	DELETE t1.* FROM archive_ids as t1 LEFT JOIN syslog AS t2 ON t1.id=t2.id WHERE t2.id IS NOT NULL;
+	-- Ignore ID's from entries that exist on abuser_evidense
+	DELETE t1.* FROM archive_ids as t1 LEFT JOIN abuser_evidence AS t2 ON t1.id=t2.archive_id WHERE t2.archive_id IS NOT NULL;
+	DELETE t1.* FROM `archive` AS t1 LEFT JOIN archive_ids AS t2 ON t1.id=t2.id WHERE t2.id IS NOT NULL;
+	COMMIT;
+  END IF;
+END IF;  
+END
+//
+
+ALTER EVENT e_rotate_archive DISABLE//

--- a/schema/echofish-events.sql
+++ b/schema/echofish-events.sql
@@ -71,4 +71,4 @@ END IF;
 END
 //
 
-ALTER EVENT e_rotate_archive DISABLE//
+


### PR DESCRIPTION
Introduce event for archive rotation of logs along with a couple of new `sysconf` flags.

The new flags
* `archive_rotate`: [yes,no] Activate archive rotation operations ?
* `archive_delete_use_mem`: [yes,no] Use ENGINE=MEMORY for the archive ID selection table. Use this option with caution.
* `archive_delete_days`: (default: 7), Number of days older entries will be deleted
* `archive_delete_limit`: (default: 0), Limit delete operations to a specific set of archive entries. No more than `archive_delete_limit` entries will be deleted.

Note that the archive rotation does not delete entries that:
* are used as evidence for the abuser module
* entries that haven't been processed yet by the archive parser
* entries that still exist on the syslog table/view (syslog/logs)
