### PR TITLE
Fix bug that introduced by the change in model()->deleteAll()

### DIFF
--- a/htdocs/protected/modules/syslog/models/Syslog.php
+++ b/htdocs/protected/modules/syslog/models/Syslog.php
@@ -187,7 +187,10 @@ class Syslog extends CActiveRecord
 
 		if($this->acknowledge!==false)
 		{	
-			$cmd = Yii::app()->db->createCommand("DELETE syslog.* FROM syslog LEFT JOIN host ON host.id=syslog.host WHERE ".$criteria->condition);
+			if($criteria->condition!="")
+				$cmd = Yii::app()->db->createCommand("DELETE syslog.* FROM syslog LEFT JOIN host ON host.id=syslog.host WHERE ".$criteria->condition);
+			else
+				$cmd = Yii::app()->db->createCommand("DELETE syslog.* FROM syslog");
 			foreach($criteria->params as $key=>$val) $cmd->bindParam($key,$val);
 			$cmd->execute();
 //			Syslog::model()->deleteAll($criteria->condition,$criteria->params);


### PR DESCRIPTION
The old model didnt respect the join conditions so we had to re-write the delete operation by hand.

This should fix the bug introduced by the previous "feature". 

Issue #28 