### PR TITLE
Add comma to make it clearer there's two ID's in the error

### DIFF
--- a/htdocs/protected/modules/settings/controllers/HostController.php
+++ b/htdocs/protected/modules/settings/controllers/HostController.php
@@ -186,7 +186,7 @@ class HostController extends Controller {
            $conflict=Host::model()->findByAttributes(
                 array('ip'=>$host->ip, 'fqdn'=>$host->fqdn, 'short'=>$host->short)
            );
-           $xtramsg="[Conflicting host IDs: ".$conflict->id." ".$host->id."]";
+           $xtramsg="[Conflicting host IDs: ".$conflict->id.", ".$host->id."]";
          }
          Yii::app()->user->setFlash('error',"<strong>Error in resolving hosts</strong> ".$xtramsg);
          $trans->rollback();


### PR DESCRIPTION
Just to make it cleaner and more obvious that it lists two ID's that are in conflict.