### PR TITLE
Documentation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,12 +15,12 @@ content. For lighter footprint, nginx with php-fpm is recommended.
 
 ### 1.2 - MySQL database
 
-Echofish backend was developed on MySQL 5.1.68 (and works fine on other 
+Echofish backend is developed on MariaDB 10.0.25 (and works fine on other 
 reasonably recent versions too).
 
-#### 1.2.1 - MySQL User Defined Functions
+#### 1.2.1 - MariaDB Regexp Functions
 
-Echofish is dependent on [lib_mysql_udf_preg](https://github.com/mysqludf/lib_mysqludf_preg/) OR MariaDB 10.0.5+ for PCRE pattern matching.
+Echofish is dependent on MariaDB 10.0.5+ for PCRE pattern matching.
 
 ### 1.3 - Syslog
 
@@ -58,25 +58,13 @@ mysql -u root -p ETS_echofish < schema/echofish-dataonly.sql
 mysql -u root -p ETS_echofish < schema/echofish-functions.sql
 mysql -u root -p ETS_echofish < schema/echofish-triggers.sql
 mysql -u root -p ETS_echofish < schema/echofish-events.sql
-```
-Import the appropriate procedures for your database server
-
-MySQL with udf_preg
-
-```sh
-mysql -u root -p ETS_echofish < schema/echofish-procedures.sql
-```
-
-MariaDB 10.0.5+
-
-```sh
 mysql -u root -p ETS_echofish < schema/echofish-procedures.mariadb10.sql
 ```
 
 For events to run, make sure you set `event_scheduler=on` somewhere under the 
 `[mysqld]` section in the default mysql config file, usually `/etc/my.cnf` or 
-`/etc/mysql/my.cnf`. After setting up the event_scheduler you may also want to 
-run `sudo /etc/init.d/mysql reload`.
+`/etc/mysql/my.cnf`. After setting up the event_scheduler you should also 
+reload the mysql server process, i.e. `service mysqld reload` or equivalent.
 
 ### 3.2 - Echofish frontend
 
@@ -152,13 +140,3 @@ whitelisting and abuser incident correlation will not work consistently. Make
 sure you have `event_scheduler=ON` in the `[mysqld]` section of `/etc/my.cnf` 
 or `/etc/mysql/my.cnf`.
 
-* lib_mysql_udf_preg fails to ./configure with WARNING: ‘aclocal-1.13′.Run 
-```
-cd lib_mysqludf_preg
-aclocal 
-libtoolize –force
-autoreconf``` 
-and try again. [lib_mysqludf_preg on CentOS 6.4](http://dragkh.wordpress.com/2013/12/18/how-to-install-mysql-10-0-6-mariadb-and-to-compile-lib_mysqludf_preg-on-centos-6-4/).
-
-* lib_mysql_udf_preg fails to load on some MySQL versions with 
-`undefined symbol: my_thread_stack_size`. Read [Can't open shared library lib_mysqludf_preg.so](https://github.com/mysqludf/lib_mysqludf_preg/issues/13).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -56,9 +56,9 @@ cd echofish/
 mysql -u root -p ETS_echofish < schema/00_echofish-schema.sql
 mysql -u root -p ETS_echofish < schema/echofish-dataonly.sql
 mysql -u root -p ETS_echofish < schema/echofish-functions.sql
+mysql -u root -p ETS_echofish < schema/echofish-procedures.mariadb10.sql
 mysql -u root -p ETS_echofish < schema/echofish-triggers.sql
 mysql -u root -p ETS_echofish < schema/echofish-events.sql
-mysql -u root -p ETS_echofish < schema/echofish-procedures.mariadb10.sql
 ```
 
 For events to run, make sure you set `event_scheduler=on` somewhere under the 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,7 +11,11 @@ mysql database backend and a web server for the frontend.
 ### 1.1 - Web server
 
 Echofish frontend should run well on most web servers capable of serving PHP 
-content. For lighter footprint, nginx with php-fpm is recommended.
+content.
+
+PHP with the mbstring extension, the MySQL PDO extension and PCRE-support is pretty much the only hard requirement for the web server environment.
+
+For lighter footprint, nginx with php-fpm is recommended.
 
 ### 1.2 - MySQL database
 

--- a/contrib/Echofish-OpenBSD-syslog_ng.md
+++ b/contrib/Echofish-OpenBSD-syslog_ng.md
@@ -61,9 +61,9 @@ cd /var/www/echofish-master
 mysql ETS_echofish < schema/00_echofish-schema.sql
 mysql ETS_echofish < schema/echofish-dataonly.sql
 mysql ETS_echofish < schema/echofish-functions.sql
+mysql ETS_echofish < schema/echofish-procedures.mariadb10.sql
 mysql ETS_echofish < schema/echofish-triggers.sql
 mysql ETS_echofish < schema/echofish-events.sql
-mysql ETS_echofish < schema/echofish-procedures.mariadb10.sql
 ```
 
 ### Echofish setup

--- a/contrib/Echofish-OpenBSD-syslog_ng.md
+++ b/contrib/Echofish-OpenBSD-syslog_ng.md
@@ -1,22 +1,22 @@
 ## Install Echofish On OpenBSD
 
 The following guide walks you through the installation of Echofish on 
-OpenBSD 5.4 with syslog-ng+nginx+php_fpm.
+OpenBSD 6.0 with syslog-ng+nginx+php_fpm.
 
 ### Requirements
 
-Starting from a fresh installation of 5.4 release, Echofish has a few
+Starting from a fresh installation of 6.0 release, Echofish has a few
  additional requirements:
 
 #### Packages
 
-We are going to use syslog-ng as a collector and MySQL as backend database. 
+We are going to use syslog-ng as a collector and MariaDB as backend database. 
 php-fpm will be used to run Echofish:
 
 ```sh
-export PKG_PATH=ftp://ftp.openbsd.org/pub/OpenBSD/$(uname -r)/packages/$(uname -m)
-pkg_add -vvi syslog-ng libdbi-drivers-mysql mysql-server 
-pkg_add -vvi php-fpm.5.3.27 php-pdo_mysql-5.3.27 pecl-APC-3.1.9p3 pcre-8.33
+export PKG_PATH=http://ftp.openbsd.org/pub/OpenBSD/$(uname -r)/packages/$(uname -m)
+pkg_add -vvi syslog-ng libdbi-drivers-mysql mariadb-server mariadb-client 
+pkg_add -vvi nginx-1.10.1 php-5.6.23p0 php-pdo_mysql-5.6.23p0 
 ```
 
 #### Echofish sources
@@ -31,25 +31,6 @@ ln -s /var/www/echofish-master/htdocs /var/www/htdocs/echofish
 install -d -g www -o www /var/www/htdocs/echofish/assets/
 ```
 
-#### Install MySQL UDF
-
-Install [lib_mysql_udf_preg](https://github.com/mysqludf/lib_mysqludf_preg/), 
-which is used for PCRE pattern matching, following 
-[its guide](https://github.com/mysqludf/lib_mysqludf_preg/blob/lib_mysqludf_preg-1.2-rc2/INSTALL):
-
-```
-ftp https://github.com/mysqludf/lib_mysqludf_preg/archive/lib_mysqludf_preg-1.2-rc2.tar.gz
-tar zxf lib_mysqludf_preg-1.2-rc2.tar.gz
-cd lib_mysqludf_preg-lib_mysqludf_preg-1.2-rc2
-./configure
-make
-make install
-make MYSQL="mysql -u root -p" installdb
-```
-
-Note: The `installdb` target of make(1) may fail to load lib_mysql_udf_preg 
-with `undefined symbol: my_thread_stack_size`. Read [Can't open shared library lib_mysqludf_preg.so](https://github.com/mysqludf/lib_mysqludf_preg/issues/13).
-
 #### Create and configure a database 
 
 Echofish requires MySQL's builtin scheduler to be enabled, so add 
@@ -59,7 +40,7 @@ Configure MySQL to start for the first time and start the service:
 
 ```
 mysql_install_db
-/etc/rc.d/mysqld -f start
+rcctl -f start mysqld
 ```
 
 Run `mysql -p -u root` to connect to your mysql server as administrator and 
@@ -80,9 +61,9 @@ cd /var/www/echofish-master
 mysql ETS_echofish < schema/00_echofish-schema.sql
 mysql ETS_echofish < schema/echofish-dataonly.sql
 mysql ETS_echofish < schema/echofish-functions.sql
-mysql ETS_echofish < schema/echofish-procedures.sql
 mysql ETS_echofish < schema/echofish-triggers.sql
 mysql ETS_echofish < schema/echofish-events.sql
+mysql ETS_echofish < schema/echofish-procedures.mariadb10.sql
 ```
 
 ### Echofish setup
@@ -138,7 +119,7 @@ return array(
 ```
 
 If you are unsure, leave 'localhost' to deliver to the local MTA. Configuring 
-cron for report generation is outside the scope of this recipe, because report 
+cron for report generation is outside the scope of this guide, because report 
 data is only produced after configuring the Abuser module. After completing 
 setup learn more about Abuser on the module's help pages within the webui.
 
@@ -153,8 +134,8 @@ Uncomment the following section in `/etc/nginx/nginx.conf`:
 
 ```
         #location ~ \.php$ {
-        #    root           /var/www/htdocs;
-        #    fastcgi_pass   127.0.0.1:9000;
+        #    try_files      $uri $uri/ =404;
+        #    fastcgi_pass   unix:run/php-fpm.sock;
         #    fastcgi_index  index.php;
         #    fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
         #    include        fastcgi_params;
@@ -182,6 +163,8 @@ logging erroneous entries, a certain configuration is required. Modify
 `/etc/syslog-ng/syslog-ng.conf` like the following:
 
 ```
+@version: 3.7
+
 # make sure we only log source IPv4 address
 options {
         use_dns(no);
@@ -192,29 +175,32 @@ options {
         stats_freq(0);
 };
 
-# in case of openbsd you can use those to replace default syslog
-# if you run other chrooted services that log to syslog you should 
-# include them here, e.g. unix-dgram ("/var/nsd/dev/log");
-source s_local {
-        unix-dgram ("/dev/log");
-        unix-dgram ("/var/empty/dev/log");
-        unix-dgram ("/var/www/dev/log");
-        internal();
+# This source includes internal syslog_ng messages and local system logs, as
+# forwarded by OpenBSD's stock syslogd(8) 
+source s_local{ 
+        udp(ip("127.0.0.1") port(514));
+        internal(); 
 };
 
+# Since 514/UDP is already occupied by syslogd(8) either listen on high port
+# or specify LAN ip address to listen on normal port
 source s_net {
-        udp(port(514));
+
+        udp(port(60514));
+# or   udp(ip("lan.ip.add.res") port(514));
 #      tcp(port(514));
 };
 
+# change the following '127.0.0.1' with the ip of the concentrator
+rewrite r_local_sethost { set("127.0.0.1", value("HOST"));};
 
 log { source(s_net); destination(d_mysql); };
-log { source(s_local); destination(d_mysql_local); };
+log { source(s_local); rewrite(r_local_sethost); destination(d_mysql); };
 
 destination d_mysql {
         sql(
                 type(mysql)
-                host("DATABASEHOST") username("USERNAME") password("PASSWORD")
+                host("127.0.0.1") username("echofish") password("{{{echofish-pass-here}}}")
                 database("ETS_echofish")
                 table("archive_bh") 
                 columns("host", "facility", "priority", "level", "received_ts", "program", "msg","pid","tag")
@@ -222,39 +208,40 @@ destination d_mysql {
         );
 };
 
-destination d_mysql_local {
-        sql(
-                type(mysql)
-                host("DATABASEHOST") username("USERNAME") password("PASSWORD")
-                database("ETS_echofish")
-                table("archive_bh") 
-                columns("host", "facility", "priority", "level", "received_ts", "program", "msg","pid","tag")
-# change the following '127.0.0.1' with the ip of the concentrator
-                values("127.0.0.1", "$FACILITY_NUM", "$PRIORITY","$LEVEL_NUM", "$YEAR-$MONTH-$DAY $HOUR:$MIN:$SEC", "$PROGRAM", "$MSG","$PID", "$TAG" )
-        );
-};
-
 ```
 
+#### Stock OpenBSD syslogd configuration
+
+To additionally forward logs from the concentrator's OS, the syslogd(8) daemon
+is configured to relay all messages to the syslog-ng daemon.
+
+Add the following lines to `/etc/syslog.conf`:
+
+```
+# Log all messages to local syslog-ng listening on 127.0.0.1
+*.*    @127.0.0.1
+```
 
 #### OpenBSD service startup
 
-Now make sure the required services are started at system boot by updating the 
-file `/etc/rc.conf.local` to include the newly installed package daemons
+Now make sure the required services are started at system boot:
 
 ```sh
-syslogd_flags=NO
-nginx_flags=""
-pkg_scripts="syslog_ng mysqld php_fpm"
+rcctl enable mysqld syslog_ng php56_fpm nginx
 ```
 
 Start the remaining services
   
 ```sh
-/etc/rc.d/syslogd stop
-/etc/rc.d/syslog_ng start 
-/etc/rc.d/php_fpm start
-/etc/rc.d/nginx start
+rcctl start syslog_ng
+rcctl start php56_fpm
+rcctl start nginx
+```
+
+Restart local syslogd:
+
+``sh`
+rcctl restart syslogd
 ```
 
 ### Test your installation

--- a/contrib/Echofish-OpenBSD-syslog_ng.md
+++ b/contrib/Echofish-OpenBSD-syslog_ng.md
@@ -182,8 +182,10 @@ source s_local{
         internal(); 
 };
 
+# This source is for logs coming to the concentrator from other hosts.
 # Since 514/UDP is already occupied by syslogd(8) either listen on high port
-# or specify LAN ip address to listen on normal port
+# or specify LAN ip address to listen on default port (514) on the specific
+# LAN interface
 source s_net {
 
         udp(port(60514));

--- a/contrib/Echofish-OpenBSD-syslog_ng.md
+++ b/contrib/Echofish-OpenBSD-syslog_ng.md
@@ -240,7 +240,7 @@ rcctl start nginx
 
 Restart local syslogd:
 
-``sh`
+```sh
 rcctl restart syslogd
 ```
 

--- a/contrib/OpenBSD-syslog-concentrator.md
+++ b/contrib/OpenBSD-syslog-concentrator.md
@@ -1,8 +1,12 @@
 ### Setting up a syslog concentrator with syslog-ng
 
-In order to be able to get all logs into the database tables and avoid logging erroneous entries
+In order to insert logs into the database tables and avoid logging erroneous entries:
 
 ```
+# syslog-ng configuration file for echofish on OpenBSD.
+
+@version: 3.7
+
 # make sure we only log source IPv4 address
 options {
         use_dns(no);
@@ -13,24 +17,28 @@ options {
         stats_freq(0);
 };
 
-# in case of openbsd you can use those to replace default syslog
-# if you run other chrooted services that log to syslog you should 
-# include them here, e.g. unix-dgram ("/var/nsd/dev/log");
+# This source includes internal syslog_ng messages and local system logs, as
+# forwarded by OpenBSD's stock syslogd(8)
 source s_local {
-        unix-dgram ("/dev/log");
-        unix-dgram ("/var/empty/dev/log");
-        unix-dgram ("/var/www/dev/log");
         internal();
+        udp(ip("127.0.0.1") port(514));
 };
 
+# This source is for logs coming to the concentrator from other hosts.
+# Since 514/UDP is already occupied by syslogd(8) either listen on high port
+# or specify LAN ip address to listen on default port (514) on the specific
+# LAN interface
 source s_net {
-        udp(port(514));
+        udp(port(60514));
+# or   udp(ip("lan.ip.add.res") port(514));
 #      tcp(port(514));
 };
 
+# change the following '127.0.0.1' with the ip of the concentrator
+rewrite r_local_sethost { set("127.0.0.1", value("HOST"));};
 
 log { source(s_net); destination(d_mysql); };
-log { source(s_local); destination(d_mysql_local); };
+log { source(s_local); rewrite(r_local_sethost); destination(d_mysql_local); };
 
 destination d_mysql {
         sql(
@@ -43,16 +51,20 @@ destination d_mysql {
         );
 };
 
-destination d_mysql_local {
-        sql(
-                type(mysql)
-                host("DATABASEHOST") username("USERNAME") password("PASSWORD")
-                database("ETS_echofish")
-                table("archive_bh") 
-                columns("host", "facility", "priority", "level", "received_ts", "program", "msg","pid","tag")
-# change the following 172.20.1.254 with the ip of the concentrator
-                values("172.20.1.254", "$FACILITY_NUM", "$PRIORITY","$LEVEL_NUM", "$YEAR-$MONTH-$DAY $HOUR:$MIN:$SEC", "$PROGRAM", "$MSG","$PID", "$TAG" )
-        );
-};
-
 ```
+
+Provided the database exists, and the web-ui is installed, after restarting
+the `syslog_ng` service, your setup should be working:
+
+```sh
+rcctl restart syslog_ng
+```
+
+Source `s_local` is configured to accept messages from localhost; we instruct
+OpenBSD's stock syslogd(8) to relay all logs from the OS to the syslog-ng
+instance, listening on 127.0.0.1:514:
+
+```sh
+echo '*.* @127.0.0.1' >> /etc/syslog.conf && rcctl restart syslogd
+```
+


### PR DESCRIPTION
Clean-up INSTALL.md (for MariaDB-only setups)
Updated contrib recipes for "Echofish on OpenBSD" and "Syslog-ng Concentrator" for OpenBSD 6.0
Added PHP requirements to INSTALL.md
Fixed "bug" with import order for schema file (so that abuser event does not end up being DISABLED on fresh setups)
