### PR TITLE
Correct and introduce fixes for OpenBSD recipe

### DIFF
--- a/contrib/Echofish-OpenBSD-syslog_ng.md
+++ b/contrib/Echofish-OpenBSD-syslog_ng.md
@@ -17,6 +17,8 @@ php-fpm will be used to run Echofish:
 export PKG_PATH=http://ftp.openbsd.org/pub/OpenBSD/$(uname -r)/packages/$(uname -m)
 pkg_add -vvi syslog-ng libdbi-drivers-mysql mariadb-server mariadb-client 
 pkg_add -vvi php-5.6.23p0 php-pdo_mysql-5.6.23p0 
+( cd /etc/php-5.6.sample
+  for i in *; do ln -sf ../php-5.6.sample/$i ../php-5.6/; done )
 ```
 
 #### Echofish sources
@@ -96,7 +98,7 @@ Edit `/var/www/htdocs/echofish/protected/config/db.php` and change the values to
 
 ```php
 		'db'=>array(
-			'connectionString' => 'mysql:host=localhost;dbname=ETS_echofish',
+			'connectionString' => 'mysql:host=127.0.0.1;dbname=ETS_echofish',
 			'emulatePrepare' => true,
 			'username' => 'echofish',
 			'password' => '{{{echofish-pass-here}}}',

--- a/contrib/Echofish-OpenBSD-syslog_ng.md
+++ b/contrib/Echofish-OpenBSD-syslog_ng.md
@@ -27,7 +27,7 @@ example extracts into /var/www/htdocs)
 ```sh
 ftp https://github.com/echothrust/echofish/archive/master.tar.gz
 tar -zxf master.tar.gz -C /var/www/
-ln -s /var/www/echofish-master/htdocs /var/www/htdocs/echofish
+ln -s ../echofish-master/htdocs /var/www/htdocs/echofish
 install -d -g www -o www /var/www/htdocs/echofish/assets/
 ```
 


### PR DESCRIPTION
Symlinks in /var/www/htdocs must be relative and pointing within /var/www (chroot for httpd). Fixed absolute link to be relative.
Added command from /usr/local/share/doc/pkg-readmes for php package, to create symlinks that load php extensions
Changed hostname in db.php connection string from localhost to 127.0.0.1, to keep php from connecting to mysql via unix socket (not present within chroot, unless we change the socket path from my.cnf).