### PR TITLE
Replaced `127.0.0.1` with `localhost`

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -64,7 +64,7 @@ and grant privileges to a user connecting from your web server's IP:
 
 ```sql
 CREATE DATABASE ETS_echofish CHARACTER SET utf8 COLLATE utf8_unicode_ci;
-GRANT ALL PRIVILEGES ON ETS_echofish.* TO 'echofish'@'127.0.0.1' IDENTIFIED BY 'place-your-passwd-here' WITH GRANT OPTION;
+GRANT ALL PRIVILEGES ON ETS_echofish.* TO 'echofish'@'localhost' IDENTIFIED BY 'place-your-passwd-here' WITH GRANT OPTION;
 FLUSH PRIVILEGES;
 ```
 


### PR DESCRIPTION
Replaced `127.0.0.1` with `localhost` as the default config file connects to `localhost`.

I know it `127.0.0.1` and `localhost` point to the same location, but MySQL permissions are picky.

I was installing from scratch and used `127.0.0.1`, and got a DB connection error. So I had to update the MySQL permissions.